### PR TITLE
serviceValidate call broken on vanilla CAS

### DIFF
--- a/lib/cas-sfu.js
+++ b/lib/cas-sfu.js
@@ -29,15 +29,14 @@ CAS.prototype.validate = function(ticket, callback) {
 	delete service.search;
 	service = url.format(service);
 
-	bodystr = 'ticket=' + ticket + '&service=' + service;
+	bodystr = '?ticket=' + ticket + '&service=' + service;
 	if (this.options.allow) {
 		bodystr += '&allow=' + this.options.allow;
 	}
 
     // call /validate with the ticket & service and call the callback
-	request.post({
-		uri: this.options.casBase + this.options.validatePath,
-		body: bodystr
+	request.get({
+		uri: this.options.casBase + this.options.validatePath + bodystr
 	}, function(err, response, body) {
 		if (err) {
 			// do something


### PR DESCRIPTION
I found that the serviceValidate call wasn't working against our local vanilla CAS install, the error looked like:

```
{ code: 'INVALID_REQUEST', '$t': '\'service\'and\'ticket\'parameters are both required' }
```

Changing the request to a GET and moving the body from the POST to query parameters seems to fix it.
